### PR TITLE
Drop flattenBuiltinByteString function

### DIFF
--- a/src/BorrowerNft.hs
+++ b/src/BorrowerNft.hs
@@ -25,14 +25,9 @@ import           Ledger.Value             as Value
 import qualified PlutusTx
 import           PlutusTx.Prelude         hiding (Semigroup (..), unless)
 
-{-# INLINABLE flattenBuiltinByteString #-}
-flattenBuiltinByteString :: [BuiltinByteString] -> BuiltinByteString
-flattenBuiltinByteString [] = emptyByteString
-flattenBuiltinByteString (x:xs) = appendByteString x $ flattenBuiltinByteString xs
-
 {-# INLINABLE borrower #-}
 borrower :: TokenName
-borrower = TokenName { unTokenName = flattenBuiltinByteString [consByteString x emptyByteString | x <- [66]]}  -- B
+borrower = TokenName { unTokenName = consByteString 66 emptyByteString }  -- B
 
 {-# INLINABLE mkPolicy #-}
 mkPolicy :: TxOutRef -> Integer -> ScriptContext -> Bool

--- a/src/LenderNft.hs
+++ b/src/LenderNft.hs
@@ -33,14 +33,9 @@ import           PlutusTx.Prelude         hiding (Semigroup (..), unless)
 import qualified Plutus.V1.Ledger.Scripts as Plutus
 import           Prelude                  (Semigroup (..), Show)
 
-{-# INLINABLE flattenBuiltinByteString #-}
-flattenBuiltinByteString :: [BuiltinByteString] -> BuiltinByteString
-flattenBuiltinByteString [] = emptyByteString
-flattenBuiltinByteString (x:xs) = appendByteString x $ flattenBuiltinByteString xs
-
 {-# INLINABLE lender #-}
 lender :: TokenName
-lender = TokenName { unTokenName = flattenBuiltinByteString [consByteString x emptyByteString | x <- [76]]}  -- L
+lender = TokenName { unTokenName = consByteString 76 emptyByteString }  -- L
 
 {-# INLINABLE mkPolicy #-}
 mkPolicy :: ValidatorHash -> TxOutRef -> Integer -> ScriptContext -> Bool

--- a/src/Liquidation.hs
+++ b/src/Liquidation.hs
@@ -34,14 +34,9 @@ import           PlutusTx.Prelude hiding (Semigroup (..), unless)
 import           Ledger.Typed.Scripts as Scripts
 import qualified Ledger as L
 
-{-# INLINABLE flattenBuiltinByteString #-}
-flattenBuiltinByteString :: [BuiltinByteString] -> BuiltinByteString
-flattenBuiltinByteString [] = emptyByteString
-flattenBuiltinByteString (x:xs) = appendByteString x $ flattenBuiltinByteString xs
-
 {-# INLINABLE borrower #-}
 borrower :: TokenName
-borrower = TokenName { unTokenName = flattenBuiltinByteString [consByteString x emptyByteString | x <- [66]]}  -- B
+borrower = TokenName { unTokenName = consByteString 66 emptyByteString }  -- B
 
 {-# INLINABLE mkValidator #-}
 mkValidator :: CurrencySymbol -> Integer -> ScriptContext -> Bool


### PR DESCRIPTION
This function is not necessary as we only have one-char strings