### PR TITLE
Apt 248 fix percentage calculations

### DIFF
--- a/src/Collateral.hs
+++ b/src/Collateral.hs
@@ -90,7 +90,7 @@ mkValidator contractInfo@ContractInfo{..} dat rdm ctx = validate
     interestPercentage :: Integer
     interestPercentage = case (mintdate rdm + repayinterval dat) < interestPayDate rdm of
       True  -> 100
-      False -> (getPOSIXTime (repayinterval dat) `multiplyInteger` 100) `divideInteger` getPOSIXTime loanHeld
+      False -> (getPOSIXTime loanHeld `multiplyInteger` 100) `divideInteger` getPOSIXTime (repayinterval dat)
        where
          loanHeld = interestPayDate rdm - mintdate rdm
 
@@ -118,14 +118,13 @@ mkValidator contractInfo@ContractInfo{..} dat rdm ctx = validate
     validateBorrowerNftBurn = any (\(cs, tn, n) -> cs == borrowersNFT dat && tn == borrower && n == (-1)) (U.mintFlattened ctx)
 
     validateBorrower :: Bool
-    validateBorrower = 
-                      --  traceIfFalse "invalid debt amount sent to interest sc" validateDebtAmnt &&
-                       traceIfFalse "invalid interest amount sent to interest sc" validateInterestAmnt -- &&
-                      --  traceIfFalse "invalid debt and interest amount" validateDebtAndInterestAmnt &&
-                      --  traceIfFalse "Lender nft is not passed on to interest sc" validateNftIsPassedOn &&
-                      --  traceIfFalse "borrower nft is not burnt" validateBorrowerNftBurn &&
-                      --  traceIfFalse "borrower deadline check fail" checkBorrowerDeadLine &&
-                      --  traceIfFalse "invalid time nft token name" checkMintTnName
+    validateBorrower = traceIfFalse "invalid debt amount sent to interest sc" validateDebtAmnt &&
+                       traceIfFalse "invalid interest amount sent to interest sc" validateInterestAmnt &&
+                       traceIfFalse "invalid debt and interest amount" validateDebtAndInterestAmnt &&
+                       traceIfFalse "Lender nft is not passed on to interest sc" validateNftIsPassedOn &&
+                       traceIfFalse "borrower nft is not burnt" validateBorrowerNftBurn &&
+                       traceIfFalse "borrower deadline check fail" checkBorrowerDeadLine &&
+                       traceIfFalse "invalid time nft token name" checkMintTnName
 
     checkDeadline :: Bool
     checkDeadline = traceIfFalse "deadline check fail" (contains (from (mintdate rdm + repayinterval dat)) (U.range ctx))

--- a/src/Collateral.hs
+++ b/src/Collateral.hs
@@ -35,13 +35,12 @@ import           Plutus.V1.Ledger.Value
 import qualified PlutusTx
 import           PlutusTx.Prelude hiding (Semigroup (..), unless)
 import           Prelude              (Show (..))
-import qualified PlutusTx.Builtins.Internal as B
 
 import           Ledger.Typed.Scripts as Scripts
 import           Ledger hiding (singleton)
 import GHC.Generics (Generic)
 import Data.Aeson (ToJSON, FromJSON)
-import PlutusTx.Builtins (equalsByteString, divideInteger, addInteger, multiplyInteger)
+import PlutusTx.Builtins (equalsByteString, divideInteger, multiplyInteger)
 import qualified Common.Utils             as U
 
 data CollateralDatum = CollateralDatum

--- a/src/Collateral.hs
+++ b/src/Collateral.hs
@@ -95,7 +95,7 @@ mkValidator contractInfo@ContractInfo{..} dat rdm ctx = validate
          loanHeld = interestPayDate rdm - mintdate rdm
 
     validateInterestAmnt :: Bool
-    validateInterestAmnt = getInterestAmnt (U.valueToSc interestscvh ctx) >= ((interestamnt dat `multiplyInteger` 100) `divideInteger` interestPercentage)
+    validateInterestAmnt = getInterestAmnt (U.valueToSc interestscvh ctx) >= ((interestamnt dat `multiplyInteger` interestPercentage) `divideInteger` 100)
 
     validateDebtAndInterestAmnt :: Bool
     validateDebtAndInterestAmnt = not ((interestcs dat == loancs dat) && (interesttn dat == loantn dat)) || (getLoanAmnt (U.valueToSc interestscvh ctx) >= loanamnt dat + interestamnt dat)
@@ -118,13 +118,14 @@ mkValidator contractInfo@ContractInfo{..} dat rdm ctx = validate
     validateBorrowerNftBurn = any (\(cs, tn, n) -> cs == borrowersNFT dat && tn == borrower && n == (-1)) (U.mintFlattened ctx)
 
     validateBorrower :: Bool
-    validateBorrower = traceIfFalse "invalid debt amount sent to interest sc" validateDebtAmnt &&
-                       traceIfFalse "invalid interest amount sent to interest sc" validateInterestAmnt &&
-                       traceIfFalse "invalid debt and interest amount" validateDebtAndInterestAmnt &&
-                       traceIfFalse "Lender nft is not passed on to interest sc" validateNftIsPassedOn &&
-                       traceIfFalse "borrower nft is not burnt" validateBorrowerNftBurn &&
-                       traceIfFalse "borrower deadline check fail" checkBorrowerDeadLine &&
-                       traceIfFalse "invalid time nft token name" checkMintTnName
+    validateBorrower = 
+                      --  traceIfFalse "invalid debt amount sent to interest sc" validateDebtAmnt &&
+                       traceIfFalse "invalid interest amount sent to interest sc" validateInterestAmnt -- &&
+                      --  traceIfFalse "invalid debt and interest amount" validateDebtAndInterestAmnt &&
+                      --  traceIfFalse "Lender nft is not passed on to interest sc" validateNftIsPassedOn &&
+                      --  traceIfFalse "borrower nft is not burnt" validateBorrowerNftBurn &&
+                      --  traceIfFalse "borrower deadline check fail" checkBorrowerDeadLine &&
+                      --  traceIfFalse "invalid time nft token name" checkMintTnName
 
     checkDeadline :: Bool
     checkDeadline = traceIfFalse "deadline check fail" (contains (from (mintdate rdm + repayinterval dat)) (U.range ctx))

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,5 +11,5 @@ main = do
       "Test Suites"
       [ Spec.Test.mainTests cfg
       , Spec.Test.testSize cfg
-      , Spec.Test.mintOracleNftTests cfg
+      -- , Spec.Test.mintOracleNftTests cfg
       ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,5 +11,5 @@ main = do
       "Test Suites"
       [ Spec.Test.mainTests cfg
       , Spec.Test.testSize cfg
-      -- , Spec.Test.mintOracleNftTests cfg
+      , Spec.Test.mintOracleNftTests cfg
       ]

--- a/test/Spec/Test.hs
+++ b/test/Spec/Test.hs
@@ -36,17 +36,17 @@ mainTests cfg =
   testGroup
     "Main tests"
     [
-      testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Happy path" happyPath
-    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower cancels loan test" borrowerCancelsLoan
-    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns full interest when loan return time has passed" returnFullLoan
-    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns less than it should then full time has passed" (mustFail returnNotEnoughInterest)
-    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns loan when half the time passed returning less than full interest" returnPartialLoan
-    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns loan when half the time passed returning less than full interest with same currency" (mustFail returnPartialLoanSameCs)
-    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns less interest than it should because of forged mintDate" (mustFail returnPartialLoanForgedMintDate)
-    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns less interest than it should" (mustFail returnPartialLoanLessThanItShoudInterestRepayed)
-    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "test loan return expiration date. Loan request expired" (mustFail provideLoanNotOnTime)
-    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "test loan return expiration date. Loan request not-expired" provideLoanOnTime
-    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "liquidate borrower" liquidateBorrower
+    --   testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Happy path" happyPath
+    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower cancels loan test" borrowerCancelsLoan
+    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns full interest when loan return time has passed" returnFullLoan
+    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns less than it should then full time has passed" (mustFail returnNotEnoughInterest)
+      testNoErrorsTrace (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns loan when half the time passed returning less than full interest" returnPartialLoan
+    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns loan when half the time passed returning less than full interest with same currency" (mustFail returnPartialLoanSameCs)
+    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns less interest than it should because of forged mintDate" (mustFail returnPartialLoanForgedMintDate)
+    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns less interest than it should" (mustFail returnPartialLoanLessThanItShoudInterestRepayed)
+    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "test loan return expiration date. Loan request expired" (mustFail provideLoanNotOnTime)
+    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "test loan return expiration date. Loan request not-expired" provideLoanOnTime
+    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "liquidate borrower" liquidateBorrower
     ]
 
 mintOracleNftTests :: BchConfig -> TestTree
@@ -503,7 +503,9 @@ returnPartialLoan = do
                         adaValue 1
               valTmp3 = fakeValue interestCoin 25 <>
                         adaValue 1
+
           intPayDate <- currentTime
+          logInfo $  "intPayDate: " ++ show intPayDate
 
           sp1 <- spend borrower valTmp1
           sp2 <- spend borrower valTmp2

--- a/test/Spec/Test.hs
+++ b/test/Spec/Test.hs
@@ -473,7 +473,8 @@ returnPartialLoan = do
   sp <- spend borrower valToPay
   let oref = getHeadRef sp
   let repayint = 20000
-  let tx = createLockFundsTx repayint borrower oref sp 100000 <> getMintBorrowerNftTx borrower oref
+  let expiration = 100000
+  let tx = createLockFundsTx repayint borrower oref sp expiration <> getMintBorrowerNftTx borrower oref
   submitTx borrower tx
   utxos <- utxoAt $ requestAddress getSc1Params -- utxoAt  :: HasAddress addr => addr -> Run [(TxOutRef, TxOut)]
   let [(lockRef, _)] = utxos

--- a/test/Spec/Test.hs
+++ b/test/Spec/Test.hs
@@ -36,17 +36,17 @@ mainTests cfg =
   testGroup
     "Main tests"
     [
-    --   testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Happy path" happyPath
-    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower cancels loan test" borrowerCancelsLoan
-    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns full interest when loan return time has passed" returnFullLoan
-    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns less than it should then full time has passed" (mustFail returnNotEnoughInterest)
-      testNoErrorsTrace (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns loan when half the time passed returning less than full interest" returnPartialLoan
-    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns loan when half the time passed returning less than full interest with same currency" (mustFail returnPartialLoanSameCs)
-    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns less interest than it should because of forged mintDate" (mustFail returnPartialLoanForgedMintDate)
-    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns less interest than it should" (mustFail returnPartialLoanLessThanItShoudInterestRepayed)
-    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "test loan return expiration date. Loan request expired" (mustFail provideLoanNotOnTime)
-    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "test loan return expiration date. Loan request not-expired" provideLoanOnTime
-    -- , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "liquidate borrower" liquidateBorrower
+      testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Happy path" happyPath
+    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower cancels loan test" borrowerCancelsLoan
+    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns full interest when loan return time has passed" returnFullLoan
+    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns less than it should then full time has passed" (mustFail returnNotEnoughInterest)
+    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns loan when half the time passed returning less than full interest" returnPartialLoan
+    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns loan when half the time passed returning less than full interest with same currency" (mustFail returnPartialLoanSameCs)
+    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns less interest than it should because of forged mintDate" (mustFail returnPartialLoanForgedMintDate)
+    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "Borrower returns less interest than it should" (mustFail returnPartialLoanLessThanItShoudInterestRepayed)
+    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "test loan return expiration date. Loan request expired" (mustFail provideLoanNotOnTime)
+    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "test loan return expiration date. Loan request not-expired" provideLoanOnTime
+    , testNoErrors (adaValue 10_000_000 <> borrowerInitialFunds <> lenderInitialFunds) cfg "liquidate borrower" liquidateBorrower
     ]
 
 mintOracleNftTests :: BchConfig -> TestTree


### PR DESCRIPTION
In `validateInterestAmnt` the interest calculations seem to be wrong. `interestamt * 100 / interestPercentage` is taken while it probably should be be `interest * interestPercentage / 100`

Same with interestPercentage function, loanHeld should be divided by repayInterval.

It works together by luck, as these mistakes cancel each other: 1 / (1/x) = x.
