### PR TITLE
Apt 245 move lender nft utxo parameterization to token name

### DIFF
--- a/app/compile-validators.hs
+++ b/app/compile-validators.hs
@@ -8,7 +8,7 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 
 import qualified Cardano.Ledger.Alonzo.Data as Alonzo
-import qualified Plutus.V1.Ledger.Api       as Plutus
+import           Plutus.V1.Ledger.Api
 import           Ledger                 (validatorHash, scriptCurrencySymbol)
 
 import qualified Data.ByteString.Short as SBS
@@ -18,38 +18,39 @@ import               Collateral
 import               Request
 import               TimeNft
 import               Liquidation
+import               LenderNft
 
-getCollateralScParams :: Collateral.ContractInfo
-getCollateralScParams = Collateral.ContractInfo {
+getCollateralScParams :: CurrencySymbol -> Collateral.ContractInfo
+getCollateralScParams cs = Collateral.ContractInfo {
         Collateral.borrower     = "B"
-      , Collateral.lender       = "L"
-      , Collateral.interestscvh = validatorHash Interest.validator
+      , Collateral.lenderNftCs  = cs
+      , Collateral.interestscvh = validatorHash (Interest.validator (Interest.ContractInfo cs))
       , Collateral.timeNft      = scriptCurrencySymbol TimeNft.policy
     }
 
-getRequestScParams :: Request.ContractInfo
-getRequestScParams = Request.ContractInfo {
+getRequestScParams :: CurrencySymbol -> Request.ContractInfo
+getRequestScParams cs = Request.ContractInfo {
         Request.borrower       = "B"
-      , Request.lender         = "L"
-      , Request.collateralcsvh = validatorHash $ Collateral.validator getCollateralScParams
+      , Request.lenderNftCs    = cs
+      , Request.collateralcsvh = validatorHash $ Collateral.validator (getCollateralScParams cs)
       , Request.timeNft        = scriptCurrencySymbol TimeNft.policy
     }
 
 main :: IO ()
 main = do
   let scriptnum = 0
-  writePlutusScript scriptnum "interest.plutus" Interest.interest interestShortBs
-  writePlutusScript scriptnum "collateral.plutus" (Collateral.collateral getCollateralScParams) (collateralShortBs getCollateralScParams)
-  writePlutusScript scriptnum "request.plutus" (Request.request getRequestScParams) (requestShortBs getRequestScParams)
+  writePlutusScript scriptnum "interest.plutus" (Interest.interest (Interest.ContractInfo $ scriptCurrencySymbol LenderNft.policy)) (interestShortBs (Interest.ContractInfo $ scriptCurrencySymbol LenderNft.policy))
+  writePlutusScript scriptnum "collateral.plutus" (Collateral.collateral (getCollateralScParams (scriptCurrencySymbol LenderNft.policy))) (collateralShortBs (getCollateralScParams (scriptCurrencySymbol LenderNft.policy)))
+  writePlutusScript scriptnum "request.plutus" (Request.request (getRequestScParams (scriptCurrencySymbol LenderNft.policy))) (requestShortBs (getRequestScParams (scriptCurrencySymbol LenderNft.policy)))
   writePlutusScript scriptnum "liquidation.plutus" Liquidation.liquidation liquidationShortBs
 
 writePlutusScript :: Integer -> FilePath -> PlutusScript PlutusScriptV1 -> SBS.ShortByteString -> IO ()
 writePlutusScript scriptnum filename scriptSerial scriptSBS =
   do
-  case Plutus.defaultCostModelParams of
+  case defaultCostModelParams of
         Just m ->
           let Alonzo.Data pData = toAlonzoData (ScriptDataNumber scriptnum)
-              (logout, e) = Plutus.evaluateScriptCounting Plutus.Verbose m scriptSBS [pData]
+              (logout, e) = evaluateScriptCounting Verbose m scriptSBS [pData]
           in do print ("Log output" :: String) >> print logout
                 case e of
                   Left evalErr -> print ("Eval Error" :: String) >> print evalErr

--- a/app/mint-lender-nft.hs
+++ b/app/mint-lender-nft.hs
@@ -8,60 +8,31 @@ import           Cardano.Api.Shelley
 
 import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import qualified Plutus.V1.Ledger.Api       as Plutus
-import           Ledger                 (validatorHash, scriptCurrencySymbol)
 
 import qualified Data.ByteString.Short as SBS
-import qualified Data.String           as FS
 
 import           LenderNft (lenderNftShortBs, lenderNft)
-import           Collateral
-import           Interest (validator)
-import           TimeNft (policy)
-
-
-getCollateralScParams :: Collateral.ContractInfo
-getCollateralScParams = Collateral.ContractInfo {
-        Collateral.borrower     = "B"
-      , Collateral.lender       = "L"
-      , Collateral.interestscvh = validatorHash Interest.validator
-      , Collateral.timeNft      = scriptCurrencySymbol TimeNft.policy
-    }
-
-getCollateralScValHash :: Plutus.ValidatorHash
-getCollateralScValHash = validatorHash $ Collateral.validator getCollateralScParams
 
 main :: IO ()
 main = do
-  args <- getArgs
-  let nargs = length args
-  let utxo = if nargs > 0 then head args else "ff"
   let scriptnum = 0
-  let scriptname = utxo ++ ".lendernft"
+  let scriptname = "lender.nft"
   putStrLn $ "Writing output to: " ++ scriptname
-  writePlutusMintingScript scriptnum scriptname lenderNft lenderNftShortBs (parseUTxO utxo)
+  writePlutusMintingScript scriptnum scriptname lenderNft lenderNftShortBs
 
-parseUTxO :: String -> Plutus.TxOutRef
-parseUTxO s =
-  let
-    (x, y) = span (/= '#') s
-  in
-    Plutus.TxOutRef (Plutus.TxId $ Plutus.getLedgerBytes $ FS.fromString x) $ read $ tail y
-
-writePlutusMintingScript :: Integer -> FilePath -> (Plutus.ValidatorHash -> Plutus.TxOutRef -> PlutusScript PlutusScriptV1) -> (Plutus.ValidatorHash -> Plutus.TxOutRef -> SBS.ShortByteString) -> Plutus.TxOutRef -> IO ()
-writePlutusMintingScript scriptnum filename scriptSerial scriptSBS utxo =
+writePlutusMintingScript :: Integer -> FilePath -> PlutusScript PlutusScriptV1 -> SBS.ShortByteString -> IO ()
+writePlutusMintingScript scriptnum filename scriptSerial scriptSBS =
   do
   case Plutus.defaultCostModelParams of
         Just m ->
           let Alonzo.Data pData = toAlonzoData (ScriptDataNumber scriptnum)
-              (logout, e) = Plutus.evaluateScriptCounting Plutus.Verbose m (scriptSBS getCollateralScValHash utxo) [pData]
+              (logout, e) = Plutus.evaluateScriptCounting Plutus.Verbose m scriptSBS [pData]
           in do print ("Log output" :: String) >> print logout
                 case e of
                   Left evalErr -> print ("Eval Error" :: String) >> print evalErr
                   Right exbudget -> print ("Ex Budget" :: String) >> print exbudget
         Nothing -> error "defaultCostModelParams failed"
-  result <- writeFileTextEnvelope filename Nothing $ scriptSerial getCollateralScValHash utxo
-  print $ "Compiled with collateral smart contract validator hash: " ++ show getCollateralScValHash
-  print $ "Utxo to be consumed" ++ show utxo
+  result <- writeFileTextEnvelope filename Nothing scriptSerial
   case result of
     Left err -> print $ displayError err
     Right () -> return ()

--- a/src/Collateral.hs
+++ b/src/Collateral.hs
@@ -70,7 +70,6 @@ data CollateralRedeemer = CollateralRedeemer
 
 data ContractInfo = ContractInfo
     { borrower     :: !TokenName
-    , lender       :: !TokenName
     , interestscvh :: !ValidatorHash
     , timeNft      :: !CurrencySymbol
     } deriving (Show, Generic, ToJSON, FromJSON)

--- a/src/Interest.hs
+++ b/src/Interest.hs
@@ -8,8 +8,12 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 {-# HLINT ignore "Use foldr" #-}
+{-# HLINT ignore "Use newtype instead of data" #-}
 
 module Interest
   ( interest
@@ -31,24 +35,31 @@ import           Plutus.V1.Ledger.Scripts
 import           Plutus.V1.Ledger.Value
 import qualified PlutusTx
 import           PlutusTx.Prelude hiding (Semigroup (..), unless)
+import           Prelude              (Show (..))
 import           Ledger.Typed.Scripts as Scripts
 import qualified Ledger as L
 import qualified Common.Utils             as U
+import GHC.Generics (Generic)
+import Data.Aeson (ToJSON, FromJSON)
+
+data ContractInfo = ContractInfo
+    { lenderNftCs  :: !CurrencySymbol
+    } deriving (Show, Generic, ToJSON, FromJSON)
 
 {-# INLINABLE mkValidator #-}
-mkValidator :: Integer -> Integer -> ScriptContext -> Bool
-mkValidator _ _ ctx = validate
+mkValidator :: ContractInfo -> Integer -> Integer -> ScriptContext -> Bool
+mkValidator contractInfo@ContractInfo{..} _ _ ctx = validate
   where
-    hasBurntNft :: CurrencySymbol -> Bool
-    hasBurntNft cs = case U.ownInput ctx of
-      Just txo -> valueOf (txOutValue txo) cs lender == 1
+    hasBurntNft :: CurrencySymbol -> TokenName -> Bool
+    hasBurntNft cs tn = case U.ownInput ctx of
+      Just txo -> valueOf (txOutValue txo) cs tn == 1
       Nothing  -> False
 
     validate :: Bool
     validate = case U.mintFlattened ctx of
       [(cs, tn, amt)] -> (amt == (-2)) &&
-                         hasBurntNft cs &&
-                         (tn == lender)
+                         cs == lenderNftCs &&
+                         hasBurntNft cs tn
       _               -> False
 
 data Interest
@@ -56,24 +67,27 @@ instance Scripts.ValidatorTypes Interest where
     type instance DatumType Interest = Integer
     type instance RedeemerType Interest = Integer
 
-typedValidator :: Scripts.TypedValidator Interest
-typedValidator = Scripts.mkTypedValidator @Interest
-    $$(PlutusTx.compile [|| mkValidator ||])
+typedValidator :: ContractInfo -> Scripts.TypedValidator Interest
+typedValidator contractInfo = Scripts.mkTypedValidator @Interest
+    ($$(PlutusTx.compile [|| mkValidator ||]) `PlutusTx.applyCode` PlutusTx.liftCode contractInfo)
     $$(PlutusTx.compile [|| wrap ||])
   where
     wrap = Scripts.wrapValidator @Integer @Integer
 
-validator :: Validator
-validator = Scripts.validatorScript typedValidator
+validator :: ContractInfo -> Validator
+validator = Scripts.validatorScript . typedValidator
 
-script :: Plutus.Script
-script = Plutus.unValidatorScript validator
+script :: ContractInfo -> Plutus.Script
+script = Plutus.unValidatorScript . validator
 
-interestShortBs :: SBS.ShortByteString
-interestShortBs = SBS.toShort . LBS.toStrict $ serialise script
+interestShortBs :: ContractInfo -> SBS.ShortByteString
+interestShortBs = SBS.toShort . LBS.toStrict . serialise . script
 
-interest :: PlutusScript PlutusScriptV1
-interest = PlutusScriptSerialised interestShortBs
+interest :: ContractInfo -> PlutusScript PlutusScriptV1
+interest = PlutusScriptSerialised . interestShortBs
 
-interestAddress :: L.Address
-interestAddress = L.scriptHashAddress $ validatorHash typedValidator
+interestAddress :: ContractInfo -> L.Address
+interestAddress = L.scriptHashAddress . validatorHash . typedValidator
+
+PlutusTx.makeIsDataIndexed ''ContractInfo [('ContractInfo, 1)]
+PlutusTx.makeLift ''ContractInfo

--- a/src/Interest.hs
+++ b/src/Interest.hs
@@ -35,10 +35,6 @@ import           Ledger.Typed.Scripts as Scripts
 import qualified Ledger as L
 import qualified Common.Utils             as U
 
-{-# INLINABLE lender #-}
-lender :: TokenName
-lender = TokenName { unTokenName = consByteString 76 emptyByteString }  -- L
-
 {-# INLINABLE mkValidator #-}
 mkValidator :: Integer -> Integer -> ScriptContext -> Bool
 mkValidator _ _ ctx = validate

--- a/src/Interest.hs
+++ b/src/Interest.hs
@@ -21,6 +21,7 @@ module Interest
   , validator
   , typedValidator
   , interestAddress
+  , ContractInfo(..)
   ) where
 
 import           Cardano.Api.Shelley (PlutusScript (..), PlutusScriptV1)

--- a/src/LenderNft.hs
+++ b/src/LenderNft.hs
@@ -51,7 +51,7 @@ mkPolicy utxo ctx = case mintedValue of
     validateTokenName tn = unTokenName tn == calculateTokenNameHash
 
     checkForOverflow :: Bool
-    checkForOverflow = lengthOfByteString (getTxId . txOutRefId $ utxo) < 256
+    checkForOverflow = txOutRefIdx utxo < 256
 
     validateMint :: TokenName -> Integer -> Bool
     validateMint tn amount = U.hasUTxO utxo ctx &&

--- a/src/LenderNft.hs
+++ b/src/LenderNft.hs
@@ -57,7 +57,7 @@ mkPolicy utxo ctx = case mintedValue of
     validateMint tn amount = U.hasUTxO utxo ctx &&
                              traceIfFalse "invalid lender nft minted amount" (amount == 2) &&
                              traceIfFalse "minted nft has invalid token name" (validateTokenName tn) &&
-                             traceIfFalse "txOutRefId of provided utxo is too big " checkForOverflow
+                             traceIfFalse "txOutRefIdx of provided utxo is too big " checkForOverflow
 
     validate :: (CurrencySymbol, TokenName, Integer) -> Bool
     validate (_cs, tn, n)

--- a/src/LenderNft.hs
+++ b/src/LenderNft.hs
@@ -30,11 +30,12 @@ import qualified Ledger.Typed.Scripts     as Scripts
 import           Ledger.Value             as Value
 import qualified PlutusTx
 import           PlutusTx.Prelude         hiding (Semigroup (..), unless)
-import qualified Common.Utils             as U
 
 {-# INLINABLE mkPolicy #-}
 mkPolicy :: TxOutRef -> ScriptContext -> Bool
-mkPolicy utxo ctx = all validate mintedValue
+mkPolicy utxo ctx = case mintedValue of
+    [val] -> validate val
+    _     -> False
   where
     mintFlattened :: [(CurrencySymbol, TokenName, Integer)]
     mintFlattened = flattenValue $ txInfoMint (scriptContextTxInfo ctx)

--- a/src/LenderNft.hs
+++ b/src/LenderNft.hs
@@ -43,7 +43,7 @@ mkPolicy utxo ctx = all validate mintedValue
     mintedValue = filter (\(cs, _tn, _n) -> cs == ownCurrencySymbol ctx) mintFlattened
 
     calculateTokenNameHash :: BuiltinByteString
-    calculateTokenNameHash = sha2_256 (consByteString (txOutRefIdx utxo) ((getTxId . txOutRefId) utxo))
+    calculateTokenNameHash = consByteString (txOutRefIdx utxo) ((getTxId . txOutRefId) utxo)
 
     validateTokenName :: TokenName -> Bool
     validateTokenName tn = unTokenName tn == calculateTokenNameHash

--- a/src/LenderNft.hs
+++ b/src/LenderNft.hs
@@ -35,8 +35,8 @@ import           Prelude                  (Semigroup (..), Show)
 import qualified Common.Utils             as U
 
 {-# INLINABLE mkPolicy #-}
-mkPolicy :: ValidatorHash -> Integer -> ScriptContext -> Bool
-mkPolicy vh _ ctx = validate
+mkPolicy :: ValidatorHash -> TxOutRef -> ScriptContext -> Bool
+mkPolicy vh utxo ctx = validate
   where
     nftIsSentToCollateralSc :: Bool
     nftIsSentToCollateralSc = traceIfFalse "minted lender nft is not sent to collateral smart contract" (valueOf (U.valueToSc vh ctx) (ownCurrencySymbol ctx) lender == 1)

--- a/src/LenderNft.hs
+++ b/src/LenderNft.hs
@@ -34,10 +34,6 @@ import qualified Plutus.V1.Ledger.Scripts as Plutus
 import           Prelude                  (Semigroup (..), Show)
 import qualified Common.Utils             as U
 
-{-# INLINABLE lender #-}
-lender :: TokenName
-lender = TokenName { unTokenName = consByteString 76 emptyByteString }  -- L
-
 {-# INLINABLE mkPolicy #-}
 mkPolicy :: ValidatorHash -> TxOutRef -> Integer -> ScriptContext -> Bool
 mkPolicy vh utxo _ ctx = validate

--- a/src/LenderNft.hs
+++ b/src/LenderNft.hs
@@ -57,12 +57,8 @@ mkPolicy utxo ctx = case mintedValue of
     validateMint tn amount = U.hasUTxO utxo ctx &&
                              traceIfFalse "invalid lender nft minted amount" (amount == 2) &&
                              traceIfFalse "minted nft has invalid token name" (validateTokenName tn) &&
-                             traceIfFalse "txOutRefIdx of provided utxo is too big " checkForOverflow
-
-    validate :: (CurrencySymbol, TokenName, Integer) -> Bool
-    validate (_cs, tn, n)
-     | n > 0     = validateMint tn n
-     | otherwise = True
+                             traceIfFalse "txOutRefIdx of provided utxo is too big " checkForOverflow ||
+                             traceIfFalse "invalid burn amount" (amount == (-2))
 
 policy :: Scripts.MintingPolicy
 policy = mkMintingPolicyScript $$(PlutusTx.compile [|| Scripts.wrapMintingPolicy mkPolicy ||])

--- a/src/LenderNft.hs
+++ b/src/LenderNft.hs
@@ -35,7 +35,7 @@ import qualified Common.Utils             as U
 {-# INLINABLE mkPolicy #-}
 mkPolicy :: TxOutRef -> ScriptContext -> Bool
 mkPolicy utxo ctx = case mintedValue of
-    [val] -> validate val
+    [(_cs, tn, n)] -> validateMint tn n
     _     -> False
   where
     mintFlattened :: [(CurrencySymbol, TokenName, Integer)]

--- a/src/LenderNft.hs
+++ b/src/LenderNft.hs
@@ -49,9 +49,13 @@ mkPolicy utxo ctx = case mintedValue of
     validateTokenName :: TokenName -> Bool
     validateTokenName tn = unTokenName tn == calculateTokenNameHash
 
+    checkForOverflow :: Bool
+    checkForOverflow = lengthOfByteString (getTxId . txOutRefId $ utxo) < 256
+
     validateMint :: TokenName -> Integer -> Bool
     validateMint tn amount = traceIfFalse "invalid lender nft minted amount" (amount == 2) &&
-                             traceIfFalse "minted nft has invalid token name" (validateTokenName tn)
+                             traceIfFalse "minted nft has invalid token name" (validateTokenName tn) &&
+                             traceIfFalse "txOutRefId of provided utxo is too big " checkForOverflow
 
     validate :: (CurrencySymbol, TokenName, Integer) -> Bool
     validate (_cs, tn, n)

--- a/src/LenderNft.hs
+++ b/src/LenderNft.hs
@@ -30,6 +30,7 @@ import qualified Ledger.Typed.Scripts     as Scripts
 import           Ledger.Value             as Value
 import qualified PlutusTx
 import           PlutusTx.Prelude         hiding (Semigroup (..), unless)
+import qualified Common.Utils             as U
 
 {-# INLINABLE mkPolicy #-}
 mkPolicy :: TxOutRef -> ScriptContext -> Bool
@@ -53,7 +54,8 @@ mkPolicy utxo ctx = case mintedValue of
     checkForOverflow = lengthOfByteString (getTxId . txOutRefId $ utxo) < 256
 
     validateMint :: TokenName -> Integer -> Bool
-    validateMint tn amount = traceIfFalse "invalid lender nft minted amount" (amount == 2) &&
+    validateMint tn amount = U.hasUTxO utxo ctx &&
+                             traceIfFalse "invalid lender nft minted amount" (amount == 2) &&
                              traceIfFalse "minted nft has invalid token name" (validateTokenName tn) &&
                              traceIfFalse "txOutRefId of provided utxo is too big " checkForOverflow
 

--- a/src/Request.hs
+++ b/src/Request.hs
@@ -58,7 +58,7 @@ PlutusTx.makeLift ''RequestDatum
 
 data ContractInfo = ContractInfo
     { borrower       :: !TokenName
-    , lender         :: !TokenName
+    , lenderNftCs    :: !CurrencySymbol
     , collateralcsvh :: !ValidatorHash
     , timeNft        :: !CurrencySymbol
     } deriving (Show, Generic, ToJSON, FromJSON)
@@ -93,8 +93,8 @@ mkValidator contractInfo@ContractInfo{..} dat _ ctx = validate
     validateMint :: Bool
     validateMint = case mintFlattened of
       [(cs, tn, amt)] -> (amt == 2) &&
-                         (tn == lender) &&
-                         (valueOf (U.valueToSc collateralcsvh ctx) cs lender == 1)
+                         (cs == lenderNftCs) &&
+                         (valueOf (U.valueToSc collateralcsvh ctx) cs tn == 1)
       _               -> False
 
     validateBorrowerMint :: Bool

--- a/test/Spec/Test.hs
+++ b/test/Spec/Test.hs
@@ -1004,7 +1004,6 @@ happyPath = do
           let tx2 = getTxInFromCollateral sp1 sp2 sp3 convertedDat (CollateralRedeemer mintTime intPayDate) lockRef <>
                     getTxOutReturn 50 borrower mintTime bmp lenderCs lenderNftRef
 
-          -- wait 2000
           logInfo $  "int pay date time: " ++ show intPayDate
           tx2 <- validateIn (from 6000) tx2
           submitTx lender tx2
@@ -1016,7 +1015,7 @@ happyPath = do
           case utxos of
             [(lockRef, _)] -> do
               let tx = getTxInFromInterestSc sp lockRef <>
-                      getTxOutFromInterestSc 50 lender LenderNft.policy lenderCs lenderNftRef
+                       getTxOutFromInterestSc 50 lender LenderNft.policy lenderCs lenderNftRef
 
               submitTx lender tx
 

--- a/test/Spec/Test.hs
+++ b/test/Spec/Test.hs
@@ -51,9 +51,9 @@ mainTests cfg =
     ]
 
 mintOracleNftTests :: BchConfig -> TestTree
-mintOracleNftTests cfg = 
-  testGroup 
-    "Mint oracle nft tests" 
+mintOracleNftTests cfg =
+  testGroup
+    "Mint oracle nft tests"
     [
       testNoErrors (adaValue 10_000_000) cfg "test mint oracle nft" mintOracleNft
     , testNoErrors (adaValue 10_000_000) cfg "test mint oracle nft without one signature" (mustFail mintOracleNftShouldFail2)
@@ -192,7 +192,7 @@ getCollatDatumFronRequestDat rqDat@RequestDatum{..} = Collateral.CollateralDatum
         }
 
 getLenderTokenName :: TxOutRef -> TokenName
-getLenderTokenName utxo = TokenName $ INT.sha2_256 (INT.consByteString (txOutRefIdx utxo) ((getTxId . txOutRefId) utxo))
+getLenderTokenName utxo = TokenName $ INT.consByteString (txOutRefIdx utxo) ((getTxId . txOutRefId) utxo)
 
 getBNftCs :: TxOutRef -> CurrencySymbol
 getBNftCs = scriptCurrencySymbol . BorrowerNft.policy
@@ -619,11 +619,11 @@ returnPartialLoanSameCs = do
           utxos <- utxoAt $ Collateral.collateralAddress (getSc2Params (scriptCurrencySymbol LenderNft.policy))
           let [(lockRef, _)] = utxos
 
-          logInfo $ "mint date: " <> show mintTime 
+          logInfo $ "mint date: " <> show mintTime
           wait 16000
 
           intPayDate <- currentTime
-          logInfo $ "pay date: " <> show intPayDate 
+          logInfo $ "pay date: " <> show intPayDate
           let tx2 = getTxInFromCollateral' sp1 sp2 convertedDat (CollateralRedeemer mintTime intPayDate) lockRef <>
                     getTxOutReturn2 borrower mintTime bmp lenderCs lenderNftRef
 
@@ -968,7 +968,7 @@ happyPath = do
   let [(lockRef, _)] = utxos
   let lenderNftRef = lockRef
   lockDat <- datumAt @RequestDatum lockRef
-  case lockDat of 
+  case lockDat of
       Just dat -> do
           mintTime <- currentTime
           let convertedDat        = getCollatDatumFronRequestDat dat
@@ -1033,7 +1033,7 @@ getTxInFromCollateraLiq lender1 lender2 dat rdm scriptTxOut =
   ]
 
 getMintOracleNftTxLiq :: Integer -> PubKeyHash -> PubKeyHash -> PubKeyHash -> Tx
-getMintOracleNftTxLiq n pkh1 pkh2 pkh3 = 
+getMintOracleNftTxLiq n pkh1 pkh2 pkh3 =
   mconcat
     [ mintValue mp (getOracleNftVal cs n)
     , payToScript Helpers.TestValidator.typedValidator


### PR DESCRIPTION
The 'L' lender token minted in Request.hs doesn't have to come from a NFT policy (there’s no way to check that), the lender might have minted it using a non-NFT policy, so they might later mint another one. They can sell the first one on an NFT-bond market, meanwhile collecting interest and loan/collateral for themselves by using the other copy of the supposed NFT.