### PR TITLE
Fix invalid required collat amnt check

### DIFF
--- a/src/Request.hs
+++ b/src/Request.hs
@@ -128,9 +128,7 @@ mkValidator contractInfo@ContractInfo{..} dat lenderTn ctx = validate
     isItToCollateral txo = txOutAddress txo == collateralSc
 
     containsRequiredCollateralAmount :: TxOut -> Bool
-    containsRequiredCollateralAmount txo = case U.ownValue ctx of
-      Just v  -> assetClassValueOf v (collateral dat) >= assetClassValueOf (txOutValue txo) (collateral dat)
-      Nothing -> False
+    containsRequiredCollateralAmount txo = collateralamnt dat <= assetClassValueOf (txOutValue txo) (collateral dat)
 
     containsNewDatum :: TxOut -> Bool
     containsNewDatum txo = case getUpperBound of


### PR DESCRIPTION
The check in Request.hs file containsRequiredCollateralAmount used the opposite value comparison.
It checked that the collateral in the input (Request script UTxO) is more or the same compared to the ongoing Collateral script UTxO. This means that the Lender used to be able to take the whole collateral when providing the loan.
Implemented change is to reverse comparison check and to compare the ongoing locked collateral to the collateral value noted in the Request datum instead of the currently locked value.