### PR TITLE
Apt 305 bad interest percentage precision

### DIFF
--- a/src/Collateral.hs
+++ b/src/Collateral.hs
@@ -85,11 +85,11 @@ mkValidator contractInfo@ContractInfo{..} dat interestPayDate ctx = validate
     getPartialInterest :: Integer
     getPartialInterest = if repayIntEnd > interestPayDate && denominator > 0
       then
-        ((getPOSIXTime (interestPayDate - lendDate dat) `multiplyInteger` 100) `multiplyInteger` interestamnt dat) `divideInteger` denominator
+        ((getPOSIXTime (interestPayDate - lendDate dat)) `multiplyInteger` interestamnt dat) `divideInteger` denominator
       else
         interestamnt dat
       where
-        denominator = getPOSIXTime (repayinterval dat) `multiplyInteger` 100
+        denominator = getPOSIXTime (repayinterval dat)
         repayIntEnd = lendDate dat + repayinterval dat
 
     validateInterestAmnt :: TxOut -> Bool


### PR DESCRIPTION
The partial interest computation goes through a few steps, losing precision on the way. Plutus uses Integer types and thus any division is flooring the (intermediary) result.

Computing the partial interest first computes the percentage of the time elapsed and rounds it down to a single percentage. Then it multiplies it by the actual interest amount. As a result, the partial interest is unnecessary rounded into approximately 1 percentage precision making the computation imprecise with the lender NFT holder losing on this. The bigger the interest amount, the bigger the loss.