### PR TITLE
Apt 303 borrower may repay loan without paying interest

### DIFF
--- a/src/Collateral.hs
+++ b/src/Collateral.hs
@@ -133,7 +133,7 @@ mkValidator contractInfo@ContractInfo{..} dat interestPayDate ctx = validate
     checkDeadline = traceIfFalse "deadline check fail" (contains (from (lendDate dat + repayinterval dat)) (U.range ctx))
 
     checkBorrowerDeadLine :: Bool
-    checkBorrowerDeadLine = traceIfFalse "borrower deadline check fail" (contains (U.range ctx) (from interestPayDate))
+    checkBorrowerDeadLine = after interestPayDate (U.range ctx)
 
     checkLNftIsBurnt :: Bool
     checkLNftIsBurnt = traceIfFalse "Lender Nft not burnt" (valueOf (txInfoMint $ U.info ctx) lenderNftCs (lenderNftTn dat) == (-1))

--- a/src/Common/Utils.hs
+++ b/src/Common/Utils.hs
@@ -52,3 +52,10 @@ tnFromAsset as = snd $ unAssetClass as
 {-# INLINEABLE valuePaidToAddress #-}
 valuePaidToAddress :: ScriptContext -> Address -> Value
 valuePaidToAddress ctx addr = mconcat (fmap txOutValue (filter (\x -> txOutAddress x == addr) (txInfoOutputs (info ctx))))
+
+
+{-# INLINEABLE getUpperBound #-}
+getUpperBound :: ScriptContext -> Maybe POSIXTime
+getUpperBound ctx = case ivTo (range ctx) of
+    UpperBound (Finite x) _ -> Just x
+    _                       -> Nothing

--- a/src/Common/Utils.hs
+++ b/src/Common/Utils.hs
@@ -53,7 +53,6 @@ tnFromAsset as = snd $ unAssetClass as
 valuePaidToAddress :: ScriptContext -> Address -> Value
 valuePaidToAddress ctx addr = mconcat (fmap txOutValue (filter (\x -> txOutAddress x == addr) (txInfoOutputs (info ctx))))
 
-
 {-# INLINEABLE getUpperBound #-}
 getUpperBound :: ScriptContext -> Maybe POSIXTime
 getUpperBound ctx = case ivTo (range ctx) of

--- a/src/Request.hs
+++ b/src/Request.hs
@@ -68,11 +68,6 @@ data ContractInfo = ContractInfo
 mkValidator :: ContractInfo -> RequestDatum -> TokenName -> ScriptContext -> Bool
 mkValidator contractInfo@ContractInfo{..} dat lenderTn ctx = validate
   where
-    getUpperBound :: Maybe POSIXTime
-    getUpperBound = case ivTo (U.range ctx) of
-      UpperBound (Finite x) _ -> Just x
-      _                       -> Nothing
-
     borrowerGetsWhatHeWants :: Bool
     borrowerGetsWhatHeWants = assetClassValueOf (U.valuePaidToAddress ctx (borrowersAddress dat)) (loan dat) == loanamnt dat
 
@@ -131,8 +126,8 @@ mkValidator contractInfo@ContractInfo{..} dat lenderTn ctx = validate
     containsRequiredCollateralAmount txo = collateralamnt dat <= assetClassValueOf (txOutValue txo) (collateral dat)
 
     containsNewDatum :: TxOut -> Bool
-    containsNewDatum txo = case getUpperBound of
-      Just ld -> findDatumHash' (expectedNewDatum ld) (U.info ctx) == txOutDatumHash txo
+    containsNewDatum txo = case U.getUpperBound ctx of
+      Just ub -> findDatumHash' (expectedNewDatum ub) (U.info ctx) == txOutDatumHash txo
       Nothing -> False
 
     checkForTokensDos :: TxOut -> Bool

--- a/test/Spec/Test.hs
+++ b/test/Spec/Test.hs
@@ -300,7 +300,7 @@ getTxOutReturn interest borrower dat valToInt oref = addMintRedeemer getBorrower
   , payToPubKey borrower (fakeValue collateralCoin 100 <> adaValue 3)
   ]
 
-getTxInFromCollateral :: [UserSpend] -> Collateral.CollateralDatum -> POSIXTime -> TxOutRef -> Tx
+getTxInFromCollateral :: [UserSpend] -> Collateral.CollateralDatum -> Integer -> TxOutRef -> Tx
 getTxInFromCollateral usps dat rdm scriptTxOut =
   mconcat
   (spendScript (Collateral.collateralTypedValidator getSc2Params) scriptTxOut rdm dat : fmap userSpend usps)
@@ -414,7 +414,7 @@ returnFullLoan = do
 
           let intDat = Collateral.lenderNftTn convertedDat
 
-          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat (intPayDate + 2000) lockRef <>
+          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat 0 lockRef <>
                     getTxOutReturn 50 borrower intDat (adaValueOf 0) borrowerNftRef
 
           logInfo $  "int pay date time: " ++ show intPayDate
@@ -471,7 +471,7 @@ returnNotEnoughInterest = do
 
           let intDat = Collateral.lenderNftTn convertedDat
 
-          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat (intPayDate + 2000) lockRef <>
+          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat 0 lockRef <>
                     getTxOutReturn 25 borrower intDat (adaValueOf 0) borrowerNftRef
           tx2 <- validateIn (interval 6000 intPayDate) tx2
           submitTx lender tx2
@@ -525,7 +525,7 @@ returnPartialLoan = do
           let [(lockRef, _)] = utxos
           let intDat = Collateral.lenderNftTn convertedDat
 
-          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat (intPayDate + 4000) lockRef <>
+          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat 0 lockRef <>
                                         getTxOutReturn 25 borrower intDat (adaValueOf 0) borrowerNftRef
 
           tx2 <- validateIn (interval 6000 (intPayDate + 2000)) tx2
@@ -619,7 +619,7 @@ returnPartialLoanSameCs = do
           intPayDate <- currentTime
           logInfo $ "pay date: " <> show intPayDate
           let intDat = Collateral.lenderNftTn convertedDat
-              tx2 = getTxInFromCollateral [sp1, sp2] convertedDat (intPayDate + 2000) lockRef <>
+              tx2 = getTxInFromCollateral [sp1, sp2] convertedDat 0 lockRef <>
                     getTxOutReturn2 borrower intDat borrowerNftRef
 
           tx2 <- validateIn (interval 24000 intPayDate) tx2
@@ -735,7 +735,7 @@ returnPartialLoanLessThanItShoudInterestRepayed = do
           let [(lockRef, _)] = utxos
           let intDat = Collateral.lenderNftTn convertedDat
 
-          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat (intPayDate + 2000) lockRef <>
+          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat 0 lockRef <>
                     getTxOutReturn interestAmount borrower intDat (adaValueOf 0) borrowerNftRef
           tx2 <- validateIn (interval 6000 intPayDate) tx2
           time <- currentTime
@@ -998,7 +998,7 @@ happyPath = do
           let [(lockRef, _)] = utxos
           let intDat = Collateral.lenderNftTn convertedDat
 
-          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat (intPayDate + 2000) lockRef <>
+          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat 0 lockRef <>
                     getTxOutReturn 50 borrower intDat (adaValueOf 0) borrowerNftRef
 
           logInfo $  "int pay date time: " ++ show intPayDate
@@ -1020,7 +1020,7 @@ happyPath = do
             _ -> pure False
       Nothing -> pure False
 
-getTxInFromCollateraLiq :: UserSpend -> UserSpend -> Collateral.CollateralDatum -> POSIXTime -> TxOutRef -> Tx
+getTxInFromCollateraLiq :: UserSpend -> UserSpend -> Collateral.CollateralDatum -> Integer -> TxOutRef -> Tx
 getTxInFromCollateraLiq lender1 lender2 dat rdm scriptTxOut =
   mconcat
   [ spendScript (Collateral.collateralTypedValidator getSc2Params) scriptTxOut rdm dat
@@ -1093,14 +1093,13 @@ liquidateBorrower = do
 
           -- loan liquidate phase
           logInfo "liquidate phase"
-          intPayDate <- currentTime
           utxos <- utxoAt $ Collateral.collateralAddress getSc2Params
           let [(lockRef, _)] = utxos
 
           lenderSpend1 <- spend lender (adaValue 2)
           lenderSpend2 <- spend lender (getLNftVal 1 getLenderNftCs lenderNftRef)
 
-          let liquidate = getTxInFromCollateraLiq lenderSpend1 lenderSpend2 convertedDat intPayDate lockRef <>
+          let liquidate = getTxInFromCollateraLiq lenderSpend1 lenderSpend2 convertedDat 0 lockRef <>
                           getMintOracleNftTxLiq 1 oracle1 oracle2 oracle3 <>
                           getTxOutLiquidate lender lenderNftRef
 
@@ -1201,7 +1200,7 @@ borrowerDosLender = do
           let [(lockRef, _)] = utxos
           let intDat = Collateral.lenderNftTn convertedDat
 
-          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat (intPayDate + 2000) lockRef <>
+          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat 0 lockRef <>
                     getTxOutReturn 50 borrower intDat (generateFakeValues' borrowerDosAmount) borrowerNftRef
 
           logInfo $  "int pay date time: " ++ show intPayDate

--- a/test/Spec/Test.hs
+++ b/test/Spec/Test.hs
@@ -414,11 +414,11 @@ returnFullLoan = do
 
           let intDat = Collateral.lenderNftTn convertedDat
 
-          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat intPayDate lockRef <>
+          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat (intPayDate + 2000) lockRef <>
                     getTxOutReturn 50 borrower intDat (adaValueOf 0) borrowerNftRef
 
           logInfo $  "int pay date time: " ++ show intPayDate
-          tx2 <- validateIn (from 6000) tx2
+          tx2 <- validateIn (interval 6000 intPayDate) tx2
           submitTx lender tx2
           pure True
       Nothing -> pure False
@@ -471,9 +471,9 @@ returnNotEnoughInterest = do
 
           let intDat = Collateral.lenderNftTn convertedDat
 
-          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat intPayDate lockRef <>
+          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat (intPayDate + 2000) lockRef <>
                     getTxOutReturn 25 borrower intDat (adaValueOf 0) borrowerNftRef
-          tx2 <- validateIn (from 6000) tx2
+          tx2 <- validateIn (interval 6000 intPayDate) tx2
           submitTx lender tx2
           pure True
       Nothing -> pure False
@@ -525,10 +525,10 @@ returnPartialLoan = do
           let [(lockRef, _)] = utxos
           let intDat = Collateral.lenderNftTn convertedDat
 
-          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat intPayDate lockRef <>
+          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat (intPayDate + 4000) lockRef <>
                                         getTxOutReturn 25 borrower intDat (adaValueOf 0) borrowerNftRef
 
-          tx2 <- validateIn (from 6000) tx2
+          tx2 <- validateIn (interval 6000 (intPayDate + 2000)) tx2
           wait 2000
           time <- currentTime
           logInfo $  "time before repaying: " ++ show time
@@ -619,10 +619,10 @@ returnPartialLoanSameCs = do
           intPayDate <- currentTime
           logInfo $ "pay date: " <> show intPayDate
           let intDat = Collateral.lenderNftTn convertedDat
-              tx2 = getTxInFromCollateral [sp1, sp2] convertedDat intPayDate lockRef <>
+              tx2 = getTxInFromCollateral [sp1, sp2] convertedDat (intPayDate + 2000) lockRef <>
                     getTxOutReturn2 borrower intDat borrowerNftRef
 
-          tx2 <- validateIn (from 24000) tx2
+          tx2 <- validateIn (interval 24000 intPayDate) tx2
 
           submitTx lender tx2
           pure True
@@ -735,9 +735,9 @@ returnPartialLoanLessThanItShoudInterestRepayed = do
           let [(lockRef, _)] = utxos
           let intDat = Collateral.lenderNftTn convertedDat
 
-          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat intPayDate lockRef <>
+          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat (intPayDate + 2000) lockRef <>
                     getTxOutReturn interestAmount borrower intDat (adaValueOf 0) borrowerNftRef
-          tx2 <- validateIn (from 6000) tx2
+          tx2 <- validateIn (interval 6000 intPayDate) tx2
           time <- currentTime
           logInfo $  "time before repaying: " ++ show time
           submitTx lender tx2
@@ -998,11 +998,11 @@ happyPath = do
           let [(lockRef, _)] = utxos
           let intDat = Collateral.lenderNftTn convertedDat
 
-          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat intPayDate lockRef <>
+          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat (intPayDate + 2000) lockRef <>
                     getTxOutReturn 50 borrower intDat (adaValueOf 0) borrowerNftRef
 
           logInfo $  "int pay date time: " ++ show intPayDate
-          tx2 <- validateIn (from 5000) tx2
+          tx2 <- validateIn (interval 5000 intPayDate) tx2
           submitTx lender tx2
 
           -- retrieve loan and interest phase
@@ -1201,11 +1201,11 @@ borrowerDosLender = do
           let [(lockRef, _)] = utxos
           let intDat = Collateral.lenderNftTn convertedDat
 
-          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat intPayDate lockRef <>
+          let tx2 = getTxInFromCollateral [sp1, sp2, sp3] convertedDat (intPayDate + 2000) lockRef <>
                     getTxOutReturn 50 borrower intDat (generateFakeValues' borrowerDosAmount) borrowerNftRef
 
           logInfo $  "int pay date time: " ++ show intPayDate
-          tx2 <- validateIn (from 6000) tx2
+          tx2 <- validateIn (interval 6000 intPayDate) tx2
           submitTx lender tx2
           pure True
       Nothing -> pure False


### PR DESCRIPTION
The partial interest calculation is proportional to the time that has elapsed since the loan was provided. It takes interestPayDate which is a redeemer to be the current time approximation. However, the timestamp may be arbitrarily chosen and thus it may be set such that the partial interest computation would compute zero interest. As a result, the borrower NFT holder can repay the loan without paying interest.

The bug lies in the insufficient time validation checking that the interestPayDate is a good enough time approximation for the use case.

checkBorrowerDeadLine = contains (U.range ctx) (from interestPayDate)

By setting the transaction validity range to (interestPayDate, infinity), this time check passes for any interestPayDate. Note that interestPayDate needs to be in the past, but the malicious borrower NFT holder’s incentive is to set it into the past. Specifically, he wants to set it to lendDate.

interestPayDate := lendDate dat

  => loanHeld = 0

  => interestPercentage = 0

  => getPartialInterest = 0