### PR TITLE
Fix liquidation vulnerability

### DIFF
--- a/src/Collateral.hs
+++ b/src/Collateral.hs
@@ -145,10 +145,11 @@ mkValidator contractInfo@ContractInfo{..} dat _ ctx = validate
       valueOf (txInfoMint $ U.info ctx) lenderNftCs (lenderNftTn dat) == (-1)
 
     checkForLiquidationToken :: Bool
-    checkForLiquidationToken =
-      all (\(_, _, n) -> n > 0)
-      $ filter (\(cs, _tn, _n) -> cs == liquidateNft dat)
-      (U.mintFlattened ctx)
+    checkForLiquidationToken = case filtered of
+        [] -> False
+        xs -> all (\(_, _, n) -> n > 0) xs
+      where
+        filtered = filter (\(cs, _tn, _n) -> cs == liquidateNft dat) (U.mintFlattened ctx)
 
     validateLiquidation :: Bool
     validateLiquidation = checkLNftIsBurnt && (checkDeadline || checkForLiquidationToken)


### PR DESCRIPTION
Because of [this](https://en.wikipedia.org/wiki/Vacuous_truth) overlook
```
ʎ> a = []
ʎ> all (\x -> False) a
True
```
A vulnerability was left.
This change fixes this vulnerability.