### PR TITLE
Fix example OracleNft vulnerability

### DIFF
--- a/src/OracleNft.hs
+++ b/src/OracleNft.hs
@@ -76,10 +76,10 @@ mkPolicy tn pkh1 pkh2 pkh3 dest _redeemer ctx = validate
 
     validate =
       singleTokenName &&
-      txSignedBy (U.info ctx) pkh1 &&
+      (txSignedBy (U.info ctx) pkh1 &&
       txSignedBy (U.info ctx) pkh2 &&
       txSignedBy (U.info ctx) pkh3 &&
-      mintedValueSentToDest || burn
+      mintedValueSentToDest || burn)
 
 policy
     :: TokenName


### PR DESCRIPTION
It was possible to mint tokens when the "correct" liquidation tokens are burnt.
That's because singleTokenName check was not needed to be fulfiled before.