### PR TITLE
Redeemers in debt request

### DIFF
--- a/app/show-dat-rdm.hs
+++ b/app/show-dat-rdm.hs
@@ -16,6 +16,7 @@ import Plutus.V1.Ledger.Credential
 import Plutus.V1.Ledger.Value
 import Spec.Test
 import Liquidator.SafetyModule as Sm
+import DebtRequest (DebtRequestRedeemer(..), DebtRequestAction(..))
 
 main :: IO ()
 main = do
@@ -26,6 +27,8 @@ main = do
   writeData "example-collateral-redeemer.json" (POSIXTime 2)
   let exampleRequestRedeemer = Redeemer (PlutusTx.toBuiltinData $ getAadaTokenName (TxOutRef "ff" 1))
   writeData "example-request-redeemer.json" exampleRequestRedeemer
+  let exampleDebtRequestRedeemer = Redeemer (PlutusTx.toBuiltinData $ (DebtRequestRedeemer TakeLoan (getAadaTokenName (TxOutRef "ff" 1))))
+  writeData "example-debt-request-redeemer.json" exampleDebtRequestRedeemer
   let exampleAadaNftRedeemer = Redeemer (PlutusTx.toBuiltinData (TxOutRef "ff" 1))
   writeData "example-aada-nft-redeemer.json" exampleAadaNftRedeemer
   let liquidationActionCancel = Redeemer (PlutusTx.toBuiltinData Sm.Cancel)

--- a/app/show-dat-rdm.hs
+++ b/app/show-dat-rdm.hs
@@ -16,7 +16,7 @@ import Plutus.V1.Ledger.Credential
 import Plutus.V1.Ledger.Value
 import Spec.Test
 import Liquidator.SafetyModule as Sm
-import DebtRequest (DebtRequestRedeemer(..), DebtRequestAction(..))
+import DebtRequest (DebtRequestRedeemer(..))
 
 main :: IO ()
 main = do
@@ -27,8 +27,10 @@ main = do
   writeData "example-collateral-redeemer.json" (POSIXTime 2)
   let exampleRequestRedeemer = Redeemer (PlutusTx.toBuiltinData $ getAadaTokenName (TxOutRef "ff" 1))
   writeData "example-request-redeemer.json" exampleRequestRedeemer
-  let exampleDebtRequestRedeemer = Redeemer (PlutusTx.toBuiltinData $ (DebtRequestRedeemer TakeLoan (getAadaTokenName (TxOutRef "ff" 1))))
-  writeData "example-debt-request-redeemer.json" exampleDebtRequestRedeemer
+  let exampleDebtRequestRedeemer = Redeemer (PlutusTx.toBuiltinData $ (TakeLoan (getAadaTokenName (TxOutRef "ff" 1))))
+  writeData "example-debt-request-redeemer-take-loan.json" exampleDebtRequestRedeemer
+  let exampleDebtRequestRedeemer = Redeemer (PlutusTx.toBuiltinData DebtRequest.Cancel)
+  writeData "example-debt-request-redeemer-cancel.json" exampleDebtRequestRedeemer
   let exampleAadaNftRedeemer = Redeemer (PlutusTx.toBuiltinData (TxOutRef "ff" 1))
   writeData "example-aada-nft-redeemer.json" exampleAadaNftRedeemer
   let liquidationActionCancel = Redeemer (PlutusTx.toBuiltinData Sm.Cancel)

--- a/example-debt-request-redeemer-cancel.json
+++ b/example-debt-request-redeemer-cancel.json
@@ -1,0 +1,4 @@
+{
+    "fields": [],
+    "constructor": 1
+}

--- a/example-debt-request-redeemer-take-loan.json
+++ b/example-debt-request-redeemer-take-loan.json
@@ -1,10 +1,6 @@
 {
     "fields": [
         {
-            "fields": [],
-            "constructor": 0
-        },
-        {
             "bytes": "4b3a43f592f577fcfcb5b0e1f42bec5182c9edc414e1f667528f56e7cf0be11d"
         }
     ],

--- a/example-debt-request-redeemer.json
+++ b/example-debt-request-redeemer.json
@@ -1,0 +1,12 @@
+{
+    "fields": [
+        {
+            "fields": [],
+            "constructor": 0
+        },
+        {
+            "bytes": "4b3a43f592f577fcfcb5b0e1f42bec5182c9edc414e1f667528f56e7cf0be11d"
+        }
+    ],
+    "constructor": 0
+}

--- a/src/DebtRequest.hs
+++ b/src/DebtRequest.hs
@@ -87,16 +87,8 @@ mkValidator contractInfo@ContractInfo{..} dat rdm ctx =
     TakeLoan -> validate
     Cancel   -> validateCancelDebtRequest
   where
-    borrowerGetsWhatHeWants :: Bool
-    borrowerGetsWhatHeWants =
-      assetClassValueOf (U.valuePaidToAddress ctx (borrowersAddress dat)) (loan dat)
-      == loanAmnt dat
-
     ownHashFilter :: Maybe ValidatorHash -> Bool
     ownHashFilter mvh = Just (ownHash ctx) == mvh
-
-    txHasOneDebtRequestInputOnly :: Bool
-    txHasOneDebtRequestInputOnly = length (filter ownHashFilter $ toValidatorHash . txOutAddress . txInInfoResolved <$> txInfoInputs (U.info ctx)) == 1
 
     txHasOneScInputOnly :: Bool
     txHasOneScInputOnly =
@@ -175,7 +167,6 @@ mkValidator contractInfo@ContractInfo{..} dat rdm ctx =
     validate =
       validateTxOuts &&
       validateMint &&
-      txHasOneDebtRequestInputOnly &&
       txHasOneScInputOnly &&
       validateExpiration
 

--- a/test/Spec/Test.hs
+++ b/test/Spec/Test.hs
@@ -1294,7 +1294,7 @@ debtRequestTest = do
               valForBorrowerToSpend = fakeValue collateralCoin 100 <> adaValue 2
 
           sp <- spend borrower valForBorrowerToSpend
-          let tx = getDebtRequestTxIn sp dat lockRef (DebtRequestRedeemer TakeLoan (getAadaTokenName borrowerNftRef))
+          let tx = getDebtRequestTxIn sp dat lockRef (TakeLoan (getAadaTokenName borrowerNftRef))
                    <> getTxOutBorrow borrower convertedDat lockRef (adaValueOf 0)
 
           tx <- validateIn (interval 2000 6000) tx

--- a/test/Spec/Test.hs
+++ b/test/Spec/Test.hs
@@ -1255,10 +1255,10 @@ getMintLenderNftTx pkh oref = addMintRedeemer getLenderNftPolicy oref $
   where
     cs  = scriptCurrencySymbol getLenderNftPolicy
 
-getDebtRequestTxIn :: UserSpend -> DebtRequestDatum -> TxOutRef -> TokenName -> Tx
-getDebtRequestTxIn usp dat scriptTxOut borrowerTn =
+getDebtRequestTxIn :: UserSpend -> DebtRequestDatum -> TxOutRef -> DebtRequestRedeemer -> Tx
+getDebtRequestTxIn usp dat scriptTxOut borrowerRdm =
   mconcat
-  [ spendScript (debtRequestTypedValidator getSc1Params') scriptTxOut borrowerTn dat
+  [ spendScript (debtRequestTypedValidator getSc1Params') scriptTxOut borrowerRdm dat
   , userSpend usp
   ]
 
@@ -1294,7 +1294,7 @@ debtRequestTest = do
               valForBorrowerToSpend = fakeValue collateralCoin 100 <> adaValue 2
 
           sp <- spend borrower valForBorrowerToSpend
-          let tx = getDebtRequestTxIn sp dat lockRef (getAadaTokenName borrowerNftRef)
+          let tx = getDebtRequestTxIn sp dat lockRef (DebtRequestRedeemer TakeLoan (getAadaTokenName borrowerNftRef))
                    <> getTxOutBorrow borrower convertedDat lockRef (adaValueOf 0)
 
           tx <- validateIn (interval 2000 6000) tx


### PR DESCRIPTION
Addresses:

@lukipuki 
[informational] We suggest using redeemers in the debt request SC, just as you do in SafetyModule.hs. It has the following advantages.
* It lowers transaction costs, there's fewer conditions evaluated
* It increases security in many cases, e.g. without redeemer you often have to have complex conditions having both AND/OR, with redeemers is just AND. 
* It makes the code easier to read (and write), making it easier to change in the futuer and less prone to errors.

@cptmikx 
mikx — 11/11/2022
[informational] Function borrowerGetsWhatHeWants  in debt request is not used. We suggest removing it.
[informational] Function txHasOneDebtRequestInputOnly checks only a subset of what txHasOneScInputOnly already checks . There's no harm in leaving it like that, but it’s not necessary. We suggest removing the txHasOneDebtRequestInputOnly check.